### PR TITLE
adding changes

### DIFF
--- a/ToolsDocker/neo4j-rdf/export-data.sh
+++ b/ToolsDocker/neo4j-rdf/export-data.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 trap 'error_handler $? $LINENO $BASH_LINENO "$BASH_COMMAND" $(printf "::%s" ${FUNCNAME[@]:-})' ERR
 
 # Constants
-readonly DATADIR="/mnt/repo"
+readonly DATADIR=${WORKING_DIR:-/mnt/repo}
 readonly LOG_FILE="${DATADIR}/neo4j-logs/conversion.log"
 readonly MAX_RETRIES=3
 readonly STARTUP_TIMEOUT=60  # seconds

--- a/ToolsDocker/qEndpoint/convert-all.sh
+++ b/ToolsDocker/qEndpoint/convert-all.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-export WORKING_DIR=/mnt/repo
+export WORKING_DIR=${WORKING_DIR:-/mnt/repo}
 
 # Check if at least one file is provided
 if [ "$#" -eq 0 ]; then

--- a/ToolsDocker/schema-gen/README.MD
+++ b/ToolsDocker/schema-gen/README.MD
@@ -1,0 +1,1 @@
+Please refer to https://github.com/frink-okn/schema-gen/blob/main/script.md

--- a/helm-chart/kace/values.yaml
+++ b/helm-chart/kace/values.yaml
@@ -25,8 +25,8 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+   fsGroup: 0
 
 securityContext: {}
   # capabilities:

--- a/src/canary/mail.py
+++ b/src/canary/mail.py
@@ -55,7 +55,8 @@ class MailCanary:
                               repository_name,
                               branch_name,
                               version,
-                              github_pr):
+                              github_pr,
+                              github_branch):
         return f"""
         <!DOCTYPE html>
         <html lang="en">
@@ -99,10 +100,12 @@ class MailCanary:
                 
                 <li>Submit the form by clicking "Create".</li>
             </ol>
-            <h4>Github Documentation Updates</h4>
+            <h4>Automated Graph Characterization Updates</h4>
             <ol>
-                <li>Here's a link to <a href="{github_pr}">Graph Documentation PR</a></li>
-                <li>Assign yourself as the reviewer and approve this PR in github if documentation aligns.</li>
+                <li>To view any changes to your automated graph characterization please follow this link: <a href="{github_branch}">
+                Graph Characterization Branch</a></li>
+                <li>We have also created a github pull request for your review <a href="{github_pr}">Link to Pull request</a></li>
+                <li>Please review this automated characterization to ensure it aligns with your Graph.</li>
             </ol>
         
             <p>When the above steps are properly completed, this version of your knowledge graph will be deployed in the 
@@ -145,7 +148,6 @@ class MailCanary:
 
         except Exception as e:
             raise e
-            print(f"Failed to send email: {e}")
 
     def notify_event(self, recipient_email, event_name, **kwargs):
         """
@@ -165,7 +167,8 @@ class MailCanary:
                           repository_name: str,
                           version: str,
                           branch_name: str,
-                          github_pr: str
+                          github_pr: str,
+                          github_branch: str,
                           ):
         repository_url = config.lakefs_public_url.rstrip('/') + '/repositories/' + repository_name
         logger.info(f"Sending review email to {recipient_email}")
@@ -174,7 +177,8 @@ class MailCanary:
             repository_name=repository_name,
             version=version,
             branch_name=branch_name,
-            github_pr=github_pr
+            github_pr=github_pr,
+            github_branch=github_branch
         )
         self.send_email(recipient_email, "Deployment Review Request", email_body)
 

--- a/src/celery_tasks/celery.py
+++ b/src/celery_tasks/celery.py
@@ -35,6 +35,7 @@ def create_hdt_conversion_job(action_payload,
                               convert_to_hdt=True,
                               hdt_path="/"
                               ):
+    logger.info(f"Convert to HDT ***************************** {type(convert_to_hdt)} : {convert_to_hdt}")
     lakefs_payload = LakefsMergeActionModel(**action_payload)
     job = JobMan()
     logger.info(lakefs_payload)

--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,9 @@ import os
 
 
 
+
+
+
 class Config(BaseModel):
     lakefs_access_key: str
     lakefs_secret_key: str
@@ -24,6 +27,7 @@ class Config(BaseModel):
     email_password: str
     smtp_port: int
     smtp_server: str
+    gh_token: str
 
 
 config = Config(
@@ -47,5 +51,6 @@ config = Config(
     email_address=os.environ.get('EMAIL_ADDRESS', ''),
     email_password=os.environ.get('EMAIL_PASSWORD', ''),
     smtp_server=os.environ.get('SMTP_SERVER', ''),
-    smtp_port=int(os.environ.get('SMTP_PORT', 25))
+    smtp_port=int(os.environ.get('SMTP_PORT', 25)),
+    gh_token=os.environ.get('GH_TOKEN', '')
 )

--- a/src/k8s/templates/documentation-job.yaml
+++ b/src/k8s/templates/documentation-job.yaml
@@ -1,0 +1,6 @@
+image: containers.renci.org/frink/schema-gen:v0.0.1
+command:
+  - /code/script.sh
+
+
+

--- a/src/k8s/templates/fuseki/server-deployment.j2
+++ b/src/k8s/templates/fuseki/server-deployment.j2
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+::::apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frink-{{ kg_name }}-fuseki-server

--- a/src/k8s/templates/fuseki/server-deployment.j2
+++ b/src/k8s/templates/fuseki/server-deployment.j2
@@ -1,4 +1,4 @@
-::::apiVersion: apps/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frink-{{ kg_name }}-fuseki-server

--- a/src/k8s/templates/hdt-conversion.yaml
+++ b/src/k8s/templates/hdt-conversion.yaml
@@ -1,4 +1,4 @@
-image: containers.renci.org/frink/qendpoint:v1.16.1
+image: containers.renci.org/frink/qendpoint:v1.16.1_1
 command:
   - /bin/convert-all.sh
 

--- a/src/server.py
+++ b/src/server.py
@@ -10,48 +10,63 @@ from canary.mail import mail_canary
 from canary.slack import slack_canary
 
 
-
 app = FastAPI(title="KACE Server",
               description="Kubernetes artifacts Creation Engine (KACE) is a webserver for "
                           "managing k8s workflows and event in sync with Lakefs data updates.")
 
 
 @app.post('/upload_hdt_callback')
-async def upload_hdt_callback(action_model: LakefsMergeActionModel, notify_email: str = Query('')):
+async def upload_hdt_callback(action_model: LakefsMergeActionModel, notify_email: str = Query(''),
+                              converted_hdt: bool = Query(False)):
     hdt_location = config.local_data_dir + '/' + action_model.repository_id + '/' + action_model.branch_id + '/hdt'
-    report_location = config.local_data_dir + '/' + action_model.repository_id + '/' + action_model.branch_id + '/report'
+    try:
+        with open(config.local_data_dir + action_model.repository_id + '/' + action_model.branch_id + '/'+ 'pr.md') as stream:
+            pr_link = stream.read()
+    except Exception as e:
+        slack_canary.notify_event("⚠️ Github documentation PR link not found",
+                                  repository_id=action_model.repository_id,
+                                  branch_id=action_model.branch_id,
+                                  error=e)
+        raise e
+
     try:
         stable_branch = await upload_files(
             repo=action_model.repository_id,
             root_branch=action_model.branch_id,
+            # If no conversion is done we will use this as a way to create a branch to tag.
             local_files=[
                 (f'{hdt_location}/graph.hdt', 'hdt'),
                 (f'{hdt_location}/graph.hdt.index.v1-1', 'hdt'),
-                # (f'{report_location}/graph_stats.json', 'report'),
-                # (f'{report_location}/riot_validate.log', 'report'),
-                # (f'{report_location}/schema.dot', 'report')
-            ]
+            ] if converted_hdt else []
         )
-        email_to = notify_email
+
         branch_name = stable_branch["stable_branch_name"]
         tag = stable_branch["future_tag"]
-
-        mail_canary.send_review_email(
-            recipient_email=email_to,
-            branch_name=branch_name,
-            version=tag,
-            repository_name=action_model.repository_id
-        )
         slack_canary.notify_event("✔️ HDT file uploaded.",
                                   repository_id=action_model.repository_id,
                                   branch_id=action_model.branch_id,
                                   )
-    except Exception as e :
+    except Exception as e:
         slack_canary.notify_event("⚠️ HDT file uploaded failed.",
                                   repository_id=action_model.repository_id,
                                   branch_id=action_model.branch_id,
                                   error=e)
+        raise e
 
+    email_to = notify_email
+    mail_canary.send_review_email(
+        recipient_email=email_to,
+        branch_name=branch_name,
+        version=tag,
+        repository_name=action_model.repository_id,
+        github_pr=pr_link
+    )
+    slack_canary.notify_event("✔️ Conversion and Documentation complete.",
+                              repository_id=action_model.repository_id,
+                              branch_id=action_model.branch_id,
+                              github_pr=pr_link,
+                              lakefs_branch=branch_name
+                              )
 
 
 @app.post('/upload_neo4j_files')
@@ -80,6 +95,7 @@ async def upload_neo4j_files(action_model: LakefsMergeActionModel):
                                   branch_id=action_model.branch_id,
                                   error=e)
 
+
 async def create_HDT_conversion_task(
         action_model: LakefsMergeActionModel,
         cpu,
@@ -87,32 +103,49 @@ async def create_HDT_conversion_task(
         ephemeral,
         java_opts,
         mem_size,
-        notify_email
+        notify_email,
+        convert_hdt,
+        hdt_path,
+        kg_name
 ):
-    rdf_files = await download_files(repo=action_model.repository_id, branch=action_model.branch_id)
+    if convert_hdt:
+        files = await download_files(repo=action_model.repository_id, branch=action_model.branch_id)
+    else:
+        files = await download_files(repo=action_model.repository_id, branch=action_model.branch_id, extensions=[
+            'hdt'
+        ])
+
+
     create_hdt_conversion_job.delay(action_model.dict(),
-                                    files_list=rdf_files,
+                                    files_list=files,
                                     cpu=cpu,
                                     memory=memory,
                                     ephemeral=ephemeral,
                                     java_opts=java_opts,
                                     mem_size=mem_size,
-                                    notify_email=notify_email
+                                    notify_email=notify_email,
+                                    convert_to_hdt=convert_hdt,
+                                    hdt_path=hdt_path,
+                                    kg_name=kg_name
                                     )
 
 
 @app.post("/convert_to_hdt")
 async def convert_to_hdt(action_model: LakefsMergeActionModel,
                          background_tasks: BackgroundTasks,
-                         cpu=Query(3),
-                         memory=Query("28Gi"),
-                         ephemeral=Query("2Gi"),
-                         java_opts=Query("-Xmx25G -Xms25G -Xss512m -XX:+UseParallelGC"),
-                         mem_size=Query("25G"),
-                         notify_email=Query('')
+                         kg_name: str = Query(),
+                         cpu: int = Query(3),
+                         memory: str = Query("28Gi"),
+                         ephemeral: str = Query("2Gi"),
+                         java_opts: str = Query("-Xmx25G -Xms25G -Xss512m -XX:+UseParallelGC"),
+                         mem_size: str = Query("25G"),
+                         notify_email: str = Query(''),
+                         hdt_exists: bool = Query(False),
+                         hdt_path: str = Query('hdt/'),
+
                          ):
     slack_canary.notify_event(
-        event_name="Converting files to HDT",
+        event_name="Merge to Main",
         repository=action_model.repository_id,
         commit=action_model.commit_id,
         branch=action_model.branch_id
@@ -125,7 +158,10 @@ async def convert_to_hdt(action_model: LakefsMergeActionModel,
                               ephemeral=ephemeral,
                               java_opts=java_opts,
                               mem_size=mem_size,
-                              notify_email=notify_email
+                              notify_email=notify_email,
+                              convert_hdt=not hdt_exists,
+                              hdt_path=hdt_path,
+                              kg_name=kg_name
                               )
     return "Started conversion, please check repo tag for uploads."
 


### PR DESCRIPTION
* Change mounting structure of conversion and documentation pods. Mounting subpath has "known" issues with file handles being stale, so sometimes what containers write to subpath might not be visible to the process that has the whole volume mounted (see thread : https://chatgpt.com/share/67ad2afa-1d60-8004-a71d-9a34883f30fa) 
* Creates a PR with static branch on graph_descriptions repo 
* Has logic for converting to hdt first then generating documentation vs just generating documentation. 
* In both cases it sends out emails to both types of teams (hdt providers , or other text based rdf , nq etc...) instructing them to create a tag on the lakefs repo . 
* requries changes to lakefs convert action yaml files to the following structure : 

```
name: Convert to HDT
description: Converts collection of RDF formats into a single hdt file
on:
  post-merge:
    branches:
      - main
hooks:
  - id: convert-to-hdt
    type: webhook
    description: Convert to hdt
    properties:
      url: "http://kace/convert_to_hdt"
      timeout: 30s
      query_params:
        kg_name: "dream-kg"
        cpu: "1"
        memory: "2Gi"
        ephemeral: "256Mi"
        java_opts: "-Xmx1G -Xms1G -XX:+UseParallelGC"
        mem_size: "1G"
        hdt_exisits: "False"
        hdt_path: "/"
        notify_email: <team-1-rep-email>

```