### PR TITLE
Support bzip and gzip compressed files

### DIFF
--- a/src/lakefs_util/io_util.py
+++ b/src/lakefs_util/io_util.py
@@ -111,12 +111,7 @@ async def download_files(repo: str, branch: str, extensions: List = None):
             os.makedirs(base_dir)
         for file_name in all_files:
             suffixes = file_name.split('.')
-            if suffixes[-1] in extensions:
-                files_downloaded.append(file_name.lstrip('/'))
-                download_path = os.path.join(base_dir, file_name)
-                await download_file(file_name, repo, branch, download_path, session)
-                logger.info(f"Download {file_name} complete")
-            elif suffixes[-2] in extensions and suffixes[-1] in ["gz", "bz2"]:
+            if (suffixes[-1] in extensions or suffixes[-2] in extensions and suffixes[-1] in ["gz", "bz2"]):
                 files_downloaded.append(file_name.lstrip('/'))
                 download_path = os.path.join(base_dir, file_name)
                 await download_file(file_name, repo, branch, download_path, session)

--- a/src/lakefs_util/io_util.py
+++ b/src/lakefs_util/io_util.py
@@ -110,7 +110,13 @@ async def download_files(repo: str, branch: str, extensions: List = None):
             logger.info(f"Directory {base_dir} does not exist; creating it ")
             os.makedirs(base_dir)
         for file_name in all_files:
-            if file_name.split('.')[-1] in extensions:
+            suffixes = file_name.split('.')
+            if suffixes[-1] in extensions:
+                files_downloaded.append(file_name.lstrip('/'))
+                download_path = os.path.join(base_dir, file_name)
+                await download_file(file_name, repo, branch, download_path, session)
+                logger.info(f"Download {file_name} complete")
+            elif suffixes[-2] in extensions and suffixes[-1] in ["gz", "bz2"]:
                 files_downloaded.append(file_name.lstrip('/'))
                 download_path = os.path.join(base_dir, file_name)
                 await download_file(file_name, repo, branch, download_path, session)


### PR DESCRIPTION
Per https://jena.apache.org/documentation/io/, `riot` CLI tool is able to natively parse `.gz` and `.bz2` during conversion to turtle. This PR makes it so that the LakeFS I/O util includes these files when downloading the files to created the combined HDT document